### PR TITLE
Remove i386 from OSX architectures

### DIFF
--- a/ABSaturator/makefile.osx
+++ b/ABSaturator/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS)

--- a/AbletonLink/makefile.osx
+++ b/AbletonLink/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.5 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/AmbPan/makefile.osx
+++ b/AmbPan/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS)

--- a/Binaural/makefile.osx
+++ b/Binaural/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Bitcrusher/makefile.osx
+++ b/Bitcrusher/makefile.osx
@@ -1,4 +1,4 @@
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Elliptic/makefile.osx
+++ b/Elliptic/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/ExpDelay/makefile.osx
+++ b/ExpDelay/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/ExpEnv/makefile.osx
+++ b/ExpEnv/makefile.osx
@@ -1,4 +1,4 @@
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS)

--- a/FIR/makefile.osx
+++ b/FIR/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/FoldbackSaturator/makefile.osx
+++ b/FoldbackSaturator/makefile.osx
@@ -1,4 +1,4 @@
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/GVerb/makefile.osx
+++ b/GVerb/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/KasFilter/makefile.osx
+++ b/KasFilter/makefile.osx
@@ -1,4 +1,4 @@
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Ladspa/makefile.osx
+++ b/Ladspa/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/MIAP/makefile.osx
+++ b/MIAP/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.5 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/MagicSine/makefile.osx
+++ b/MagicSine/makefile.osx
@@ -1,4 +1,4 @@
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Mesh2D/makefile.osx
+++ b/Mesh2D/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Multicomb/makefile.osx
+++ b/Multicomb/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/NHHall/makefile.osx
+++ b/NHHall/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-std=c++11 -mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Overdrive/makefile.osx
+++ b/Overdrive/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/PanN/makefile.osx
+++ b/PanN/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Perlin/makefile.osx
+++ b/Perlin/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/PitchTrack/makefile.osx
+++ b/PitchTrack/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/PowerADSR/makefile.osx
+++ b/PowerADSR/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Random/makefile.osx
+++ b/Random/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Sigmund/makefile.osx
+++ b/Sigmund/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Spectacle/makefile.osx
+++ b/Spectacle/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/WPDiodeLadder/makefile.osx
+++ b/WPDiodeLadder/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/WPKorg35/makefile.osx
+++ b/WPKorg35/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/Wavetable/makefile.osx
+++ b/Wavetable/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC

--- a/WinFuncEnv/makefile.osx
+++ b/WinFuncEnv/makefile.osx
@@ -1,5 +1,5 @@
 
-ARCHS?=i386 x86_64
+ARCHS?=x86_64
 ARCHOPTS=$(addprefix -arch ,$(ARCHS))
 
 FLAGS+=-mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I$(CK_SRC_PATH) $(ARCHOPTS) -fPIC


### PR DESCRIPTION
I couldn't build with i386 included in the OSX architectures
```
$ make osx
CHUCK_STRICT=1 make -C ABSaturator/ osx
clang++ -mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I../chuck/include/ -arch i386 -arch x86_64 -O3 -Werror -c -o ABSaturator.o ABSaturator.cpp
clang++ -mmacosx-version-min=10.9 -D__MACOSX_CORE__ -I../chuck/include/ -arch i386 -arch x86_64 -O3 -Werror -c -o Filters.o Filters.cpp
clang++ -mmacosx-version-min=10.9 -shared -lc++ -arch i386 -arch x86_64 -o ABSaturator.chug ABSaturator.o Filters.o
ld: warning: The i386 architecture is deprecated for macOS (remove from the Xcode build setting: ARCHS)
ld: warning: ignoring file /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd, missing required architecture i386 in file /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd
ld: warning: ignoring file /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libc++.tbd, missing required architecture i386 in file /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libc++.tbd
Undefined symbols for architecture i386:
  "__Unwind_Resume", referenced from:
      _absaturator_ctor in ABSaturator.o
  "operator delete(void*)", referenced from:
      _absaturator_ctor in ABSaturator.o
      _absaturator_dtor in ABSaturator.o
  "operator new(unsigned long)", referenced from:
      _absaturator_ctor in ABSaturator.o
  "___gxx_personality_v0", referenced from:
      _absaturator_ctor in ABSaturator.o
      Dwarf Exception Unwind Info (__eh_frame) in ABSaturator.o
  "___stack_chk_fail", referenced from:
      ABSaturator::ABSaturator(float) in ABSaturator.o
  "___stack_chk_guard", referenced from:
      ABSaturator::ABSaturator(float) in ABSaturator.o
  "_log10f", referenced from:
      _absaturator_setDriveDb in ABSaturator.o
      _absaturator_getDriveDb in ABSaturator.o
  "_pow", referenced from:
      _absaturator_setDriveDb in ABSaturator.o
ld: symbol(s) not found for architecture i386
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [ABSaturator.chug] Error 1
make: *** [ABSaturator/ABSaturator.chug] Error 2
```
Is that a valid build target any more?